### PR TITLE
Kong Admin Service

### DIFF
--- a/alpha/koli/templates/deployment.yaml
+++ b/alpha/koli/templates/deployment.yaml
@@ -183,7 +183,7 @@ spec:
             curl -s -X POST http://127.0.0.1:8001/apis/ \
                 --data "name=kongadmin" \
                 --data "upstream_url=http://127.0.0.1:8001" \
-                --data "hosts={{.Values.kong.bootstrap.kongadminapi}}" >/dev/null
+                --data "hosts={{.Values.kong.bootstrap.kongadminapi}}, kong-admin.koli-system, kong-admin" >/dev/null
             
             # Sleep forever
             /bin/bash -c "trap : TERM INT; sleep infinity & wait"
@@ -203,8 +203,9 @@ spec:
       - name: koli-controller
         image: quay.io/koli/kong-ingress:{{.Values.images.kongingress}}
         args:
+        - --v=4
         - --apiserver={{.Values.k8s.apiserver}}
-        - --kong-server=http://kong-admin:8001
+        - --kong-server=http://kong-admin:8000
         - --logtostderr
         - --tls-insecure
 ---

--- a/alpha/koli/templates/svc.yaml
+++ b/alpha/koli/templates/svc.yaml
@@ -29,6 +29,21 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: kong-admin
+spec:
+  externalIPs:
+  - {{.Values.k8s.serviceip}}
+  ports:
+  - name: kong-admin
+    port: 8000
+    targetPort: 8000
+    protocol: TCP
+  selector:
+    app: kong
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: kong-proxy
 spec:
   externalIPs:


### PR DESCRIPTION
- Added kong admin service. Fixes #5 
- Since kong-admin (port 8001) binds localhost only I've provided access internally by service + kong request address `kong-admin.koli-system` or `kong-admin` or customizable by `kong.bootstrap.kongadminapi`
- Verbose 4 by default (during alpha)